### PR TITLE
Fix hooks m1

### DIFF
--- a/qemu/accel/tcg/cputlb.c
+++ b/qemu/accel/tcg/cputlb.c
@@ -1449,7 +1449,10 @@ load_helper(CPUArchState *env, target_ulong addr, TCGMemOpIdx oi,
                     continue;
                 if (!HOOK_BOUND_CHECK(hook, addr))
                     continue;
-                if ((handled = ((uc_cb_eventmem_t)hook->callback)(uc, UC_MEM_FETCH_UNMAPPED, addr, size - uc->size_recur_mem, 0, hook->user_data)))
+                tb_exec_lock(uc->tcg_ctx);
+                handled = ((uc_cb_eventmem_t)hook->callback)(uc, UC_MEM_FETCH_UNMAPPED, addr, size - uc->size_recur_mem, 0, hook->user_data);
+                tb_exec_unlock(uc->tcg_ctx);
+                if ((handled))
                     break;
 
                 // the last callback may already asked to stop emulation

--- a/qemu/accel/tcg/cputlb.c
+++ b/qemu/accel/tcg/cputlb.c
@@ -1419,6 +1419,9 @@ load_helper(CPUArchState *env, target_ulong addr, TCGMemOpIdx oi,
             uintptr_t retaddr, MemOp op, bool code_read,
             FullLoadHelper *full_load)
 {
+    // Hack for double load on error
+    if (env->uc->cpu->exit_request) return 0;
+
     uintptr_t mmu_idx = get_mmuidx(oi);
     uintptr_t index = tlb_index(env, mmu_idx, addr);
     CPUTLBEntry *entry = tlb_entry(env, mmu_idx, addr);

--- a/qemu/accel/tcg/translate-all.c
+++ b/qemu/accel/tcg/translate-all.c
@@ -1090,6 +1090,7 @@ void tcg_exec_init(struct uc_struct *uc, unsigned long tb_size)
     code_gen_alloc(uc, tb_size);
     tb_exec_unlock(uc->tcg_ctx);
     tcg_prologue_init(uc->tcg_ctx);
+    tb_exec_lock(uc->tcg_ctx);
     /* cpu_interrupt_handler is not used in uc1 */
     uc->l1_map = g_malloc0(sizeof(void *) * V_L1_MAX_SIZE);
     /* Invalidate / Cache TBs */

--- a/qemu/exec.c
+++ b/qemu/exec.c
@@ -1087,8 +1087,8 @@ RAMBlock *qemu_ram_alloc_from_ptr(struct uc_struct *uc, ram_addr_t size, void *h
     RAMBlock *new_block;
     ram_addr_t max_size = size;
 
-    size = HOST_PAGE_ALIGN(uc, size);
-    max_size = HOST_PAGE_ALIGN(uc, max_size);
+    // size = HOST_PAGE_ALIGN(uc, size);
+    // max_size = HOST_PAGE_ALIGN(uc, max_size);
     new_block = g_malloc0(sizeof(*new_block));
     if (new_block == NULL)
         return NULL;

--- a/qemu/softmmu/cpus.c
+++ b/qemu/softmmu/cpus.c
@@ -220,6 +220,9 @@ void resume_all_vcpus(struct uc_struct* uc)
         uc_exit_invalidate_iter((gpointer)&uc->exits[uc->nested_level - 1], NULL, (gpointer)uc);
     }
 
+    // Why?
+    tb_exec_lock(uc->tcg_ctx);
+
     cpu->created = false;
 }
 

--- a/tests/unit/test_arm64.c
+++ b/tests/unit/test_arm64.c
@@ -196,7 +196,7 @@ static void test_arm64_mrs_hook(void)
 }
 
 
-static void test_arm64_correct_address_in_small_jump_hook_callback(uc_engine *uc, int type, uint64_t address, int size, int64_t value, void *user_data)
+static bool test_arm64_correct_address_in_small_jump_hook_callback(uc_engine *uc, int type, uint64_t address, int size, int64_t value, void *user_data)
 {
   // Check registers
   uint64_t r_x0 = 0x0;
@@ -209,6 +209,8 @@ static void test_arm64_correct_address_in_small_jump_hook_callback(uc_engine *uc
   // Check address
   // printf("%lx\n", address);
   TEST_CHECK(address == 0x7F00);
+
+  return false;
 }
 
 static void test_arm64_correct_address_in_small_jump_hook(void)
@@ -237,7 +239,7 @@ static void test_arm64_correct_address_in_small_jump_hook(void)
     OK(uc_close(uc));
 }
 
-static void test_arm64_correct_address_in_long_jump_hook_callback(uc_engine *uc, int type, uint64_t address, int size, int64_t value, void *user_data)
+static bool test_arm64_correct_address_in_long_jump_hook_callback(uc_engine *uc, int type, uint64_t address, int size, int64_t value, void *user_data)
 {
   // Check registers
   uint64_t r_x0 = 0x0;
@@ -250,6 +252,8 @@ static void test_arm64_correct_address_in_long_jump_hook_callback(uc_engine *uc,
   // Check address
   // printf("%lx\n", address);
   TEST_CHECK(address == 0x7FFFFFFFFFFFFF00);
+
+  return false;
 }
 
 static void test_arm64_correct_address_in_long_jump_hook(void)

--- a/tests/unit/test_riscv.c
+++ b/tests/unit/test_riscv.c
@@ -538,7 +538,7 @@ static void test_riscv64_mmio_map(void)
 }
 
 
-static void test_riscv_correct_address_in_small_jump_hook_callback(uc_engine *uc, int type, uint64_t address, int size, int64_t value, void *user_data)
+static bool test_riscv_correct_address_in_small_jump_hook_callback(uc_engine *uc, int type, uint64_t address, int size, int64_t value, void *user_data)
 {
   // Check registers
   uint64_t r_x5 = 0x0;
@@ -551,6 +551,7 @@ static void test_riscv_correct_address_in_small_jump_hook_callback(uc_engine *uc
   // Check address
   // printf("%lx\n", address);
   TEST_CHECK(address == 0x7F00);
+  return false;
 }
 
 static void test_riscv_correct_address_in_small_jump_hook(void)
@@ -579,7 +580,7 @@ static void test_riscv_correct_address_in_small_jump_hook(void)
     OK(uc_close(uc));
 }
 
-static void test_riscv_correct_address_in_long_jump_hook_callback(uc_engine *uc, int type, uint64_t address, int size, int64_t value, void *user_data)
+static bool test_riscv_correct_address_in_long_jump_hook_callback(uc_engine *uc, int type, uint64_t address, int size, int64_t value, void *user_data)
 {
   // Check registers
   uint64_t r_x5 = 0x0;
@@ -592,6 +593,7 @@ static void test_riscv_correct_address_in_long_jump_hook_callback(uc_engine *uc,
   // Check address
   // printf("%lx\n", address);
   TEST_CHECK(address == 0x7FFFFFFFFFFFFF00);
+  return false;
 }
 
 static void test_riscv_correct_address_in_long_jump_hook(void)

--- a/tests/unit/test_x86.c
+++ b/tests/unit/test_x86.c
@@ -911,7 +911,6 @@ static void test_x86_nested_emu_stop(void)
 static void test_x86_nested_emu_start_error_cb(uc_engine *uc, uint64_t addr,
                                                size_t size, void *data)
 {
-      printf("ADDRESS: %lx\n", addr);
     uc_assert_err(UC_ERR_READ_UNMAPPED,
                   uc_emu_start(uc, code_start + 2, 0, 0, 0));
 }
@@ -993,7 +992,6 @@ static bool test_x86_correct_address_in_small_jump_hook_callback(uc_engine *uc, 
   TEST_CHECK(r_rip == 0x7F00);
 
   // Check address
-  printf("ADDRESS: %lx\n", address);
   TEST_CHECK(address == 0x7F00);
 
   return false;
@@ -1026,6 +1024,23 @@ static void test_x86_correct_address_in_small_jump_hook(void)
     OK(uc_close(uc));
 }
 
+static void test_x86_cpuid_1()
+{
+    uc_engine *uc;
+    char code[] = "\xB8\x01\x00\x00\x00\x0F\xA2"; // MOV EAX,1; CPUID
+    int reg;
+
+    uc_common_setup(&uc, UC_ARCH_X86, UC_MODE_32, code, sizeof(code) - 1);
+
+    OK(uc_emu_start(uc, code_start, code_start + sizeof(code) - 1, 0, 0));
+
+    OK(uc_reg_read(uc, UC_X86_REG_EDX, &reg));
+
+    TEST_CHECK(reg == 0x7088100);
+
+    OK(uc_close(uc));
+}
+
 static bool test_x86_correct_address_in_long_jump_hook_callback(uc_engine *uc, int type, uint64_t address, int size, int64_t value, void *user_data)
 {
   // Check registers
@@ -1037,7 +1052,6 @@ static bool test_x86_correct_address_in_long_jump_hook_callback(uc_engine *uc, i
   TEST_CHECK(r_rip == 0x7FFFFFFFFFFFFF00);
 
   // Check address
-  printf("ADDRESS: %lx\n", address);
   TEST_CHECK(address == 0x7FFFFFFFFFFFFF00);
 
   return false;
@@ -1105,4 +1119,5 @@ TEST_LIST = {
     {"test_x86_nested_uc_emu_start_exits", test_x86_nested_uc_emu_start_exits},
     {"test_x86_correct_address_in_small_jump_hook", test_x86_correct_address_in_small_jump_hook},
     {"test_x86_correct_address_in_long_jump_hook", test_x86_correct_address_in_long_jump_hook},
+    {"test_x86_cpuid_1", test_x86_cpuid_1},
     {NULL, NULL}};

--- a/tests/unit/test_x86.c
+++ b/tests/unit/test_x86.c
@@ -911,6 +911,7 @@ static void test_x86_nested_emu_stop(void)
 static void test_x86_nested_emu_start_error_cb(uc_engine *uc, uint64_t addr,
                                                size_t size, void *data)
 {
+      printf("ADDRESS: %lx\n", addr);
     uc_assert_err(UC_ERR_READ_UNMAPPED,
                   uc_emu_start(uc, code_start + 2, 0, 0, 0));
 }
@@ -981,7 +982,7 @@ static void test_x86_nested_uc_emu_start_exits(void)
     OK(uc_close(uc));
 }
 
-static void test_x86_correct_address_in_small_jump_hook_callback(uc_engine *uc, int type, uint64_t address, int size, int64_t value, void *user_data)
+static bool test_x86_correct_address_in_small_jump_hook_callback(uc_engine *uc, int type, uint64_t address, int size, int64_t value, void *user_data)
 {
   // Check registers
   uint64_t r_rax = 0x0;
@@ -992,8 +993,10 @@ static void test_x86_correct_address_in_small_jump_hook_callback(uc_engine *uc, 
   TEST_CHECK(r_rip == 0x7F00);
 
   // Check address
-  // printf("%lx\n", address);
+  printf("ADDRESS: %lx\n", address);
   TEST_CHECK(address == 0x7F00);
+
+  return false;
 }
 
 static void test_x86_correct_address_in_small_jump_hook(void)
@@ -1023,7 +1026,7 @@ static void test_x86_correct_address_in_small_jump_hook(void)
     OK(uc_close(uc));
 }
 
-static void test_x86_correct_address_in_long_jump_hook_callback(uc_engine *uc, int type, uint64_t address, int size, int64_t value, void *user_data)
+static bool test_x86_correct_address_in_long_jump_hook_callback(uc_engine *uc, int type, uint64_t address, int size, int64_t value, void *user_data)
 {
   // Check registers
   uint64_t r_rax = 0x0;
@@ -1034,8 +1037,10 @@ static void test_x86_correct_address_in_long_jump_hook_callback(uc_engine *uc, i
   TEST_CHECK(r_rip == 0x7FFFFFFFFFFFFF00);
 
   // Check address
-  // printf("%lx\n", address);
+  printf("ADDRESS: %lx\n", address);
   TEST_CHECK(address == 0x7FFFFFFFFFFFFF00);
+
+  return false;
 }
 
 static void test_x86_correct_address_in_long_jump_hook(void)


### PR DESCRIPTION
~~Fix~~ patch https://github.com/unicorn-engine/unicorn/issues/1615 and https://github.com/unicorn-engine/unicorn/pull/1608

- Adding `tb_exec_lock`s needed for Mac M1
- Ignore second hooks calls after memory mapping error (bug)
- Comment page align macro because is not working properly

Maybe we need to iterate this solutions, but now I have all tests green and it's working with PharoVM